### PR TITLE
ayelet/block_unauthenticated_routes_from_saving_with_tenant

### DIFF
--- a/lib/multitenant.rb
+++ b/lib/multitenant.rb
@@ -71,11 +71,7 @@ module Multitenant
           m.send "#{association}=".to_sym, Multitenant.current_tenant
 
           if Thread.current[:unauthenticated_route]
-            $logger.info(
-              message: 'account_id was assigned by multitenant in an unauthenticated route', 
-              request_path: Thread.current[:request_path], 
-              request_domain: Thread.current[:request_domain]
-            )
+            raise AccessException, 'account_id was assigned by multitenant in an unauthenticated route'
           end
         elsif tenant_id != Multitenant.current_tenant.id
           raise AccessException, "Can't create a new instance for tenant #{tenant_id} while Multitenant.current_tenant is #{Multitenant.current_tenant.id}"


### PR DESCRIPTION
raise error instead of log when multitenant account id is assigned from unauthenticated route
